### PR TITLE
Include air temperature for detecting frost condition

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <Company>JJP Home</Company>
     <Copyright>Copyright © JJP Homeworks 2020</Copyright>
     <Product>Pool Automation system</Product>
-    <Version>1.1.0</Version>
+    <Version>1.1.2</Version>
 
   </PropertyGroup>
 

--- a/src/Pool.Control/PoolControlPump.cs
+++ b/src/Pool.Control/PoolControlPump.cs
@@ -10,6 +10,7 @@ namespace Pool.Control
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
+
     using Pool.Control.Store;
     using Pool.Hardware;
 
@@ -158,7 +159,8 @@ namespace Pool.Control
                 if (this.poolSettings.WorkingMode == PoolWorkingMode.Winter && pumpOn == false)
                 {
                     // If water temperature of the pipe < threshold, inject a new cycle
-                    if (this.systemState.WaterTemperature.Value < this.poolSettings.FrostProtection.TemperatureActivation)
+                    if (this.systemState.WaterTemperature.Value < this.poolSettings.FrostProtection.WaterTemperatureActivation
+                        && this.systemState.AirTemperature.Value < this.poolSettings.FrostProtection.AirTemperatureCondition)
                     {
                         // Add pumping cycle of xx minutes
                         this.pumpCycle = new PumpCycle(

--- a/src/Pool.Control/Store/FrostProtectionSetting.cs
+++ b/src/Pool.Control/Store/FrostProtectionSetting.cs
@@ -19,14 +19,20 @@ namespace Pool.Control.Store
     {
         public FrostProtectionSetting()
         {
-            this.TemperatureActivation = 7;
+            this.WaterTemperatureActivation = 7;
+            this.AirTemperatureCondition = 0;
             this.RecyclingDurationMinutes = 15;
         }
 
         /// <summary>
+        /// Gets or sets the air temperature threshold.
+        /// </summary>
+        public double AirTemperatureCondition { get; set; }
+
+        /// <summary>
         /// Gets or sets the temperature threshold.
         /// </summary>
-        public double TemperatureActivation { get; set; }
+        public double WaterTemperatureActivation { get; set; }
 
         /// <summary>
         /// Gets or sets the recycling duration of the pump.


### PR DESCRIPTION
Include air temperature for detecting frost condition (Not only water temperature)

This prevents to activate frost protection if air temperature is positive